### PR TITLE
Simplify Messages module state

### DIFF
--- a/server/server.json
+++ b/server/server.json
@@ -18,7 +18,7 @@
     {
       "id": "5f58bcd7e81abbc8cde13cde",
       "name": "ut officia aliqua",
-      "last_updated": "2021-01-19T23:29:45.313Z"
+      "last_updated": "2020-07-26T11:58:12"
     },
     {
       "id": "5f58bcd7a3d6fed0fd68b7a9",
@@ -237,41 +237,6 @@
       "isUser": true,
       "last_updated": "2021-01-14T23:53:53.259Z",
       "text": "This is an example of a message sent via this app. Only these messages are editable. (Click the edit button below to edit me)."
-    },
-    {
-      "conversation": "5f58bcd7e81abbc8cde13cde",
-      "id": "7655be94-6ec6-49ac-9521-44de4d707032",
-      "isUser": true,
-      "last_updated": "2021-01-19T19:30:50.055Z",
-      "text": "fdsfasfdsafds!!!!!!!!!"
-    },
-    {
-      "conversation": "5f58bcd7e81abbc8cde13cde",
-      "id": "b1acc904-dc39-4416-bff2-8d1b239b33c6",
-      "isUser": true,
-      "last_updated": "2021-01-19T19:45:01.776Z",
-      "text": ""
-    },
-    {
-      "conversation": "5f58bcd7e81abbc8cde13cde",
-      "id": "8f461306-03e4-41fa-ba3d-a4366a392301",
-      "isUser": true,
-      "last_updated": "2021-01-19T19:47:22.502Z",
-      "text": "ddddd"
-    },
-    {
-      "conversation": "5f58bcd7e81abbc8cde13cde",
-      "id": "fd1768df-759a-4090-ab52-c658287c6720",
-      "isUser": true,
-      "last_updated": "2021-01-19T23:26:17.271Z",
-      "text": "s"
-    },
-    {
-      "conversation": "5f58bcd7e81abbc8cde13cde",
-      "id": "7b24bf15-c20f-4c70-a438-203776e699c0",
-      "isUser": true,
-      "last_updated": "2021-01-19T23:29:45.313Z",
-      "text": "hello 55"
     }
   ]
 }

--- a/server/server.json
+++ b/server/server.json
@@ -18,7 +18,7 @@
     {
       "id": "5f58bcd7e81abbc8cde13cde",
       "name": "ut officia aliqua",
-      "last_updated": "2020-07-26T11:58:12"
+      "last_updated": "2021-01-19T23:29:45.313Z"
     },
     {
       "id": "5f58bcd7a3d6fed0fd68b7a9",
@@ -237,6 +237,41 @@
       "isUser": true,
       "last_updated": "2021-01-14T23:53:53.259Z",
       "text": "This is an example of a message sent via this app. Only these messages are editable. (Click the edit button below to edit me)."
+    },
+    {
+      "conversation": "5f58bcd7e81abbc8cde13cde",
+      "id": "7655be94-6ec6-49ac-9521-44de4d707032",
+      "isUser": true,
+      "last_updated": "2021-01-19T19:30:50.055Z",
+      "text": "fdsfasfdsafds!!!!!!!!!"
+    },
+    {
+      "conversation": "5f58bcd7e81abbc8cde13cde",
+      "id": "b1acc904-dc39-4416-bff2-8d1b239b33c6",
+      "isUser": true,
+      "last_updated": "2021-01-19T19:45:01.776Z",
+      "text": ""
+    },
+    {
+      "conversation": "5f58bcd7e81abbc8cde13cde",
+      "id": "8f461306-03e4-41fa-ba3d-a4366a392301",
+      "isUser": true,
+      "last_updated": "2021-01-19T19:47:22.502Z",
+      "text": "ddddd"
+    },
+    {
+      "conversation": "5f58bcd7e81abbc8cde13cde",
+      "id": "fd1768df-759a-4090-ab52-c658287c6720",
+      "isUser": true,
+      "last_updated": "2021-01-19T23:26:17.271Z",
+      "text": "s"
+    },
+    {
+      "conversation": "5f58bcd7e81abbc8cde13cde",
+      "id": "7b24bf15-c20f-4c70-a438-203776e699c0",
+      "isUser": true,
+      "last_updated": "2021-01-19T23:29:45.313Z",
+      "text": "hello 55"
     }
   ]
 }

--- a/src/components/message-bubble/__snapshots__/message-bubble.spec.tsx.snap
+++ b/src/components/message-bubble/__snapshots__/message-bubble.spec.tsx.snap
@@ -28,6 +28,7 @@ exports[`MessageBubble should match snapshot for non user message 1`] = `
   <styled.p
     styles="
     margin: 0 0 10px;
+    white-space: pre-wrap;
 "
   >
     text
@@ -67,6 +68,7 @@ exports[`MessageBubble should match snapshot for user message (apply correct con
   <styled.p
     styles="
     margin: 0 0 10px;
+    white-space: pre-wrap;
 "
   >
     text

--- a/src/components/message-bubble/message-bubble.spec.tsx
+++ b/src/components/message-bubble/message-bubble.spec.tsx
@@ -29,6 +29,12 @@ describe('MessageBubble', () => {
         wrapper.find({ 'data-test-id': 'edit-button' }).simulate('click');
 
         expect(props.onClick).toHaveBeenCalledTimes(1);
-        expect(props.onClick).toHaveBeenCalledWith('id', 'text');
+        expect(props.onClick).toHaveBeenCalledWith({
+            conversation: 'convo',
+            id: 'id',
+            isUser: true,
+            last_updated: 'a long time ago, in a galaxy far away',
+            text: 'text',
+        });
     });
 });

--- a/src/components/message-bubble/message-bubble.tsx
+++ b/src/components/message-bubble/message-bubble.tsx
@@ -3,14 +3,14 @@ import { DateAndTime } from '../date-and-time/date-and-time';
 import { MessageBubbleProps as Props } from '../../../types';
 import * as Styled from './message-bubble-style';
 
-export const MessageBubble: FC<Props> = ({ id, isUser, last_updated, onClick, text }: Props): ReactElement => (
-    <Styled.Bubble isUser={isUser}>
-        <Styled.Text>{text}</Styled.Text>
-        {isUser && (
-            <Styled.Button data-test-id="edit-button" onClick={() => onClick(id, text)} type="button">
+export const MessageBubble: FC<Props> = ({ onClick, ...props }: Props): ReactElement => (
+    <Styled.Bubble isUser={props.isUser}>
+        <Styled.Text>{props.text}</Styled.Text>
+        {props.isUser && (
+            <Styled.Button data-test-id="edit-button" onClick={() => onClick(props)} type="button">
                 Edit
             </Styled.Button>
         )}
-        <DateAndTime>{last_updated}</DateAndTime>
+        <DateAndTime>{props.last_updated}</DateAndTime>
     </Styled.Bubble>
 );

--- a/src/modules/messages/messages-redux.tsx
+++ b/src/modules/messages/messages-redux.tsx
@@ -13,11 +13,13 @@ export const loadMessages = (conversation: string): Action => async (dispatch) =
     }
 };
 
-export const editMessage = (conversation: string, id: string, text: string): Action => async (dispatch) => {
-    dispatch({ type: MessageActions.EDIT, payload: { key: conversation, id, text } });
+export const editMessage = (message: Message): Action => async (dispatch) => {
+    dispatch({ type: MessageActions.EDIT, payload: message });
 
     // If I had more time I would properly handle this error case in a try/catch block and render a notification informing the user the EDIT failed and undo the optimistic action above
-    setData(`${Endpoints.MESSAGES}/${id}`, 'PATCH', { text }).catch(() => dispatch({ type: ErrorActions.FATAL }));
+    setData(`${Endpoints.MESSAGES}/${message.id}`, 'PATCH', { text: message.text }).catch(() =>
+        dispatch({ type: ErrorActions.FATAL }),
+    );
 };
 
 export const sendMessage = (conversation: string, text: string): Action => async (dispatch) => {
@@ -36,7 +38,7 @@ export const messagesReducer = (state: MessageState = {}, { payload, type }: Any
         case MessageActions.EDIT:
             return {
                 ...state,
-                [payload.key]: state[payload.key].map((message) =>
+                [payload.conversation]: state[payload.conversation].map((message) =>
                     message.id === payload.id ? { ...message, text: payload.text } : message,
                 ),
             };

--- a/src/modules/messages/test/messages-redux.spec.ts
+++ b/src/modules/messages/test/messages-redux.spec.ts
@@ -45,17 +45,11 @@ describe('message redux', () => {
     });
 
     describe('editMessage', () => {
-        const expectedAction = {
-            payload: {
-                id: 'id',
-                key: 'convo',
-                text: 'NEW TEXTY',
-            },
-            type: 'messages/EDIT',
-        };
+        const message = { conversation: 'convo', id: 'id', last_updated: '888', text: 'NEW TEXTY' };
+        const expectedAction = { payload: message, type: 'messages/EDIT' };
 
         it('should dispatch correct EDITED action', async () => {
-            await store.dispatch(editMessage('convo', 'id', 'NEW TEXTY'));
+            await store.dispatch(editMessage(message));
 
             expect(setData).toHaveBeenCalledTimes(1);
             expect(setData).toHaveBeenCalledWith('messages/id', 'PATCH', { text: 'NEW TEXTY' });
@@ -77,7 +71,7 @@ describe('message redux', () => {
 
         it('should dispatch ERROR action if messages PATCH requert fails', async () => {
             (setData as jest.Mock).mockRejectedValueOnce(new Error());
-            await store.dispatch(editMessage('convo', 'id', 'NEW TEXTY'));
+            await store.dispatch(editMessage(message));
 
             expect(store.getActions()).toEqual([expectedAction, { type: 'error/FATAL' }]);
         });

--- a/types.ts
+++ b/types.ts
@@ -52,7 +52,7 @@ export enum MessageActions {
 }
 
 export interface MessageBubbleProps extends Message {
-    onClick: (id: string, text: string) => void;
+    onClick: (message: Message) => void;
 }
 
 export interface MessageState {


### PR DESCRIPTION
**Changes**

- Previously `Messages` stored both `editID` & `editText` via react `useState` hooks. Simplify this by just storing the entire message object.
- Previously we rendered `<span ref={anchor} />` in order to scroll user to bottom of feed on message length change. Improve this by attaching the `ref` to the 'feed' node instead. Allows us to render less markup.